### PR TITLE
add unit testing example to end of Dockerfile, as suggested in #8

### DIFF
--- a/debian/r-base/Dockerfile
+++ b/debian/r-base/Dockerfile
@@ -24,3 +24,10 @@ RUN apt-get install -y --no-install-recommends r-base r-base-dev r-recommended l
 
 ## Install a few more things that are useful
 RUN apt-get install -y --no-install-recommends vim-tiny less wget
+
+
+## Run the package tests and examples (but not vignette builders), and stop if any fail.
+RUN mkdir tests \
+&& Rscript --default-packages="stats, graphics, grDevices, datasets, utils, methods, base" -e 'fails <- sapply(installed.packages()[,"Package"], tools::testInstalledPackage, outDir="/tests", types=c("examples", "tests")); if(any(fails)) stop()' \
+&& rm -rf tests/
+


### PR DESCRIPTION
This adds unit testing to the end of the Dockerfile. Not sure if this is the best way to go about this, but just a thought.  Note that 
- I found I had to use Rscript and specify the default packages loaded by `R` in order to get some of the packages to successfully pass their tests.  
- I've also added a call to explicitly make the build fail if the tests don't pass, though perhaps that's not the desired behavior.  
- I've set the tests to just run `examples` and `tests` and not build vignettes.  Maybe we want to build vignettes, but at the moment some of these will fail, for instance, Rcpp in hadleyverse because the highlighter package isn't installed ...

Haven't added these tests to other images yet, just thought I'd start with this one as a pull request to see what you think.  
