### PR TITLE
split 'overview' and 'getting started'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # rocker #
 
-## Overview and Getting Started ##
+## Overview ##
 
-This repository contains Dockerfiles for different Docker containers of interest to R users. To get started right away, ensure you have [Docker installed](https://docs.docker.com/installation/) and start a container with `docker run --rm -ti rocker/r-base` (see [here](https://docs.docker.com/reference/run/) for the `docker run` command options). In this case we are starting the `r-base` container (the base package to build from) in an interactive mode, see below for details of the other containers currently available. To get started on the `rstudio` container or its derivative containers (eg. `hadleyverse` and `ropensci`) you need to open a port, see the [instructions in the wiki](https://github.com/rocker-org/rocker/wiki/Using-the-RStudio-Image). The [wiki](https://github.com/rocker-org/rocker/wiki) also contains further instructions and information on the project, including how to extend these images and contribute to development.
+This repository contains Dockerfiles for different Docker containers of interest to R users. 
+
+## Getting Started ##
+
+To get started right away, ensure you have [Docker installed](https://docs.docker.com/installation/) and start a container with `docker run --rm -ti rocker/r-base` (see [here](https://docs.docker.com/reference/run/) for the `docker run` command options). In this case we are starting the `r-base` container (the base package to build from) in an interactive mode, see below for details of the other containers currently available. To get started on the `rstudio` container or its derivative containers (eg. `hadleyverse` and `ropensci`) you need to open a port, see the [instructions in the wiki](https://github.com/rocker-org/rocker/wiki/Using-the-RStudio-Image). The [wiki](https://github.com/rocker-org/rocker/wiki) also contains further instructions and information on the project, including how to extend these images and contribute to development.
 
 ## Status ##
 


### PR DESCRIPTION
Yes, I hesitated about merging the two sections, and your comment on #60 confirms that was a poor choice. Here they are separate again. In this PR, the 'getting started' section is distinct but still visible to the casual browser coming from twitter, etc., with a minimum of scrolling. Hope that helps.
