### PR TITLE
Sandbox

### DIFF
--- a/debian/rstudio/userconf.sh
+++ b/debian/rstudio/userconf.sh
@@ -4,12 +4,15 @@
 USER=${USER:=rstudio}
 PASSWORD=${PASSWORD:=rstudio}
 EMAIL=${EMAIL:=rstudio@example.com}
-UID=${UID:=1000}
+USERID=${USERID:=1000}
+
+echo $USER
+echo $USERID
 
 ## Things get messy if we have more than one user.  Best to delete it.  
 userdel docker
 ## Configure user account name and password (used by rstudio)
-useradd -m $USER -u $UID && echo "$USER:$PASSWORD" | chpasswd
+useradd -m $USER -u $USERID && echo "$USER:$PASSWORD" | chpasswd
 ## User must own their home directory, or RStudio won't be able to load
 ## (Note this is only necessary if the user is linking a shared volume to a subdir of this directory)
 mkdir /home/$USER && chown $USER:$USER /home/$USER


### PR DESCRIPTION
whoops, another conflict in the script as well:

Can't set UID to a default, because it already has a default (0, the root user).   Solution: Just use a different name for the UID of the user we're creating. 

Actually tested this works locally too, finally ;-) 
