### PR TITLE
`repos` should contain named strings

### DIFF
--- a/debian/r-base/Dockerfile
+++ b/debian/r-base/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update -qq \
 &&  rm -rf /tmp/downloaded_packages/
 
 ## Set a default CRAN Repo
-RUN echo 'options("repos"="http://cran.rstudio.com")' >> /etc/R/Rprofile.site
+RUN echo 'options(repos = list(CRAN = "http://cran.at.r-project.org/"))' >> /etc/R/Rprofile.site
 
 ## Set a default user. Available via runtime flag `--user docker` 
 ## Add user to 'staff' group, granting them write privileges to /usr/local/lib/R/site.library


### PR DESCRIPTION
Using `rocker/hadleyverse` on windows 7, I encountered the exact issue described [here](https://support.rstudio.com/hc/communities/public/questions/200871876-Problems-with-RStudio-v0-98b-Preview-Release): I can't use the RStudio buttons to install/update packages. This PR applies the fix from that RStudio support thread, which does indeed fix the problem for me.
