### PR TITLE
switch to jessie and drop dist-upgrade

### DIFF
--- a/debian/r-base/Dockerfile
+++ b/debian/r-base/Dockerfile
@@ -1,17 +1,11 @@
 ## Emacs, make this -*- mode: sh; -*-
-
-## start with Debian testing rolling releases
-FROM debian:testing
+ 
+FROM debian:jessie
 
 ## This handle reaches Carl and Dirk
 MAINTAINER "Carl Boettiger and Dirk Eddelbuettel" rocker-maintainers@eddelbuettel.com
 
-## Remain current
-RUN apt-get update -qq \
-&& apt-get dist-upgrade -y
-
 ## Now install R and littler, and create a link for littler in /usr/local/bin
-## NB until littler 0.2.1 is out, we are filling in a local deb package 
 RUN apt-get update -qq \
 &&  apt-get install -y --no-install-recommends \
     ed \
@@ -42,7 +36,7 @@ RUN useradd docker \
 && addgroup docker staff
 
 
-## Configure default locale
+## Configure default locale, see https://github.com/rocker-org/rocker/issues/19
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
 && locale-gen en_US.utf8 \
 && /usr/sbin/update-locale LANG=en_US.UTF-8


### PR DESCRIPTION
as recommended by the Docker team in our PR to `official-images`.

@eddelbuettel look okay?  I suppose tying this to Jessie means that when the next Debian release is named we have to update things (e.g. have separate directories corresponding to the version tags for each of the different releases).  Guess we can cross that bridge when we get there.  

I also added an inline note about setting locales, linking to issue #19 which discussed that choice. If this looks good then go ahead and merge and then I'll update the PR to official images, adding the tag for 3.1.1 and commenting on the things we've addressed. 
