### PR TITLE
move a few things around for improved cache

### DIFF
--- a/debian/r-base/Dockerfile
+++ b/debian/r-base/Dockerfile
@@ -5,18 +5,36 @@ FROM debian:jessie
 ## This handle reaches Carl and Dirk
 MAINTAINER "Carl Boettiger and Dirk Eddelbuettel" rocker-maintainers@eddelbuettel.com
 
+## Set a default user. Available via runtime flag `--user docker` 
+## Add user to 'staff' group, granting them write privileges to /usr/local/lib/R/site.library
+## User should also have & own a home directory (for rstudio or linked volumes to work properly). (could use adduser to create this automatically instead)
+RUN useradd docker \
+&& mkdir /home/docker \
+&& chown docker:docker /home/docker \
+&& addgroup docker staff
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ed \
+    less \
+    locales \
+    vim-tiny \
+    wget
+
+## Configure default locale, see https://github.com/rocker-org/rocker/issues/19
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+&& locale-gen en_US.utf8 \
+&& /usr/sbin/update-locale LANG=en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+ENV R_BASE_VERSION 3.1.1
+
 ## Now install R and littler, and create a link for littler in /usr/local/bin
 RUN apt-get update -qq \
 &&  apt-get install -y --no-install-recommends \
-    ed \
-    less \
     littler \
-    locales \
-    r-base \
-    r-base-dev \
-    r-recommended \
-    vim-tiny \
-    wget \
+    r-base=${R_BASE_VERSION}* \
+    r-base-dev=${R_BASE_VERSION}* \
+    r-recommended=${R_BASE_VERSION}* \
 &&  ln -s /usr/share/doc/littler/examples/install.r /usr/local/bin/install.r \
 &&  ln -s /usr/share/doc/littler/examples/install2.r /usr/local/bin/install2.r \
 &&  ln -s /usr/share/doc/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
@@ -27,18 +45,4 @@ RUN apt-get update -qq \
 ## Set a default CRAN Repo
 RUN echo 'options(repos = list(CRAN = "http://cran.rstudio.com/"))' >> /etc/R/Rprofile.site
 
-## Set a default user. Available via runtime flag `--user docker` 
-## Add user to 'staff' group, granting them write privileges to /usr/local/lib/R/site.library
-## User should also have & own a home directory (for rstudio or linked volumes to work properly). (could use adduser to create this automatically instead)
-RUN useradd docker \
-&& mkdir /home/docker \
-&& chown docker:docker /home/docker \
-&& addgroup docker staff
-
-
-## Configure default locale, see https://github.com/rocker-org/rocker/issues/19
-RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
-&& locale-gen en_US.utf8 \
-&& /usr/sbin/update-locale LANG=en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-
+CMD ["R"]


### PR DESCRIPTION
- separated the non-essential bits from the essential bits so that the former can be cached completely
- added an explicit pinned version for the packages from `src:r-base` so there's a natural cache-bust when it's time to update
- moved several blocks higher in the file so they can be cached completely as well
- added a default command, so that if someone does `docker run -it --rm r-base`, they're dropped straight into a useful R shell

This is more of what @yosifkit was trying to say in https://github.com/docker-library/official-images/pull/310#issuecomment-62637859 (specifically item 3 there).  I figured a pull request would make it easier to understand, since then it's a concrete proposal. :+1:

In the case of the official images, we treat them more like Debian packaging than Automated Builds are -- ie, an explicit upstream version, etc.  Hopefully that helps make this make more sense?  Happy to try to explain more if not. :smile:
