### PR TITLE
Use https for CRAN mirror in r-base

### DIFF
--- a/r-base/Dockerfile
+++ b/r-base/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
 		locales \
 		vim-tiny \
 		wget \
+		ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
 
 ## Configure default locale, see https://github.com/rocker-org/rocker/issues/19
@@ -44,7 +45,7 @@ RUN apt-get update \
 		r-base=${R_BASE_VERSION}* \
 		r-base-dev=${R_BASE_VERSION}* \
 		r-recommended=${R_BASE_VERSION}* \
-        && echo 'options(repos = list(CRAN = "http://cran.rstudio.com/"))' >> /etc/R/Rprofile.site \
+        && echo 'options(repos = list(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /etc/R/Rprofile.site \
         && echo 'source("/etc/R/Rprofile.site")' >> /etc/littler.r \
 	&& ln -s /usr/share/doc/littler/examples/install.r /usr/local/bin/install.r \
 	&& ln -s /usr/share/doc/littler/examples/install2.r /usr/local/bin/install2.r \

--- a/r-devel/Dockerfile
+++ b/r-devel/Dockerfile
@@ -89,7 +89,7 @@ RUN cd /tmp/R-devel \
 RUN echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /usr/local/lib/R/etc/Renviron
 
 ## Set default CRAN repo
-RUN echo 'options("repos"="http://cran.rstudio.com")' >> /usr/local/lib/R/etc/Rprofile.site
+RUN echo 'options(repos = list(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /usr/local/lib/R/etc/Rprofile.site
 
 RUN cd /usr/local/bin \
 && mv R Rdevel \


### PR DESCRIPTION
It may be on the early side for this, but now that the RStudio CRAN mirror supports https, I thought it would be good to enable it in the rocker images.

Installing the `ca-certificates` package also results in installing `openssl`, for a total of about 1.6 MB. 

If this looks good to you guys, I'll also update the r-devel Dockerfile.