### PR TITLE
Change repos from list to character vector

### DIFF
--- a/r-base/Dockerfile
+++ b/r-base/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update \
 		r-base=${R_BASE_VERSION}* \
 		r-base-dev=${R_BASE_VERSION}* \
 		r-recommended=${R_BASE_VERSION}* \
-        && echo 'options(repos = list(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /etc/R/Rprofile.site \
+        && echo 'options(repos = c(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /etc/R/Rprofile.site \
         && echo 'source("/etc/R/Rprofile.site")' >> /etc/littler.r \
 	&& ln -s /usr/share/doc/littler/examples/install.r /usr/local/bin/install.r \
 	&& ln -s /usr/share/doc/littler/examples/install2.r /usr/local/bin/install2.r \

--- a/r-devel/Dockerfile
+++ b/r-devel/Dockerfile
@@ -89,7 +89,7 @@ RUN cd /tmp/R-devel \
 RUN echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /usr/local/lib/R/etc/Renviron
 
 ## Set default CRAN repo
-RUN echo 'options(repos = list(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /usr/local/lib/R/etc/Rprofile.site
+RUN echo 'options(repos = c(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /usr/local/lib/R/etc/Rprofile.site
 
 RUN cd /usr/local/bin \
 && mv R Rdevel \


### PR DESCRIPTION
Currently the `repos` are set to a named list, but they should be a named character vector, according to the docs for `install.packages`:

> repos: character vector, the base URL(s) of the repositories to use, e.g., the URL of a CRAN mirror such as "http://cran.us.r-project.org". For more details on supported URL schemes see url.

This caused an incompatibility with a new feature in RStudio. Although we haven't seen this cause problems in R itself, it's still a good idea to make it conform to the documentation.