### PR TITLE
make smaller image, removes a bunch of stuff and abbreviates number of RUN

### DIFF
--- a/r-base/Dockerfile
+++ b/r-base/Dockerfile
@@ -1,5 +1,5 @@
 ## Emacs, make this -*- mode: sh; -*-
- 
+
 FROM debian:testing
 
 ## This handle reaches Carl and Dirk
@@ -13,24 +13,6 @@ RUN useradd docker \
 	&& chown docker:docker /home/docker \
 	&& addgroup docker staff
 
-RUN apt-get update \ 
-	&& apt-get install -y --no-install-recommends \
-		ed \
-		less \
-		locales \
-		vim-tiny \
-		wget \
-		ca-certificates \
-	&& rm -rf /var/lib/apt/lists/*
-
-## Configure default locale, see https://github.com/rocker-org/rocker/issues/19
-RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
-	&& locale-gen en_US.utf8 \
-	&& /usr/sbin/update-locale LANG=en_US.UTF-8
-
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-
 ## Use Debian unstable via pinning -- new style via APT::Default-Release
 RUN echo "deb http://http.debian.net/debian sid main" > /etc/apt/sources.list.d/debian-unstable.list \
 	&& echo 'APT::Default-Release "testing";' > /etc/apt/apt.conf.d/default
@@ -40,19 +22,35 @@ ENV R_BASE_VERSION 3.2.2
 ## Now install R and littler, and create a link for littler in /usr/local/bin
 ## Also set a default CRAN repo, and make sure littler knows about it too
 RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		ed \
+		less \
+		locales \
+		vim-tiny \
+		wget \
+		ca-certificates \
+	&& locale-gen --purge en_US.UTF-8 \
 	&& apt-get install -t unstable -y --no-install-recommends \
 		littler/unstable \
 		r-base=${R_BASE_VERSION}* \
 		r-base-dev=${R_BASE_VERSION}* \
 		r-recommended=${R_BASE_VERSION}* \
-        && echo 'options(repos = c(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /etc/R/Rprofile.site \
-        && echo 'source("/etc/R/Rprofile.site")' >> /etc/littler.r \
+	&& echo 'options(repos = c(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /etc/R/Rprofile.site \
+	&& echo 'source("/etc/R/Rprofile.site")' >> /etc/littler.r \
 	&& ln -s /usr/share/doc/littler/examples/install.r /usr/local/bin/install.r \
 	&& ln -s /usr/share/doc/littler/examples/install2.r /usr/local/bin/install2.r \
 	&& ln -s /usr/share/doc/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
 	&& ln -s /usr/share/doc/littler/examples/testInstalled.r /usr/local/bin/testInstalled.r \
 	&& install.r docopt \
 	&& rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get purge -y build-essential cpp cpp-5 dpkg-dev \
+	g++ g++-5 gcc gcc-5 gfortran gfortran-5 perl-modules fonts-dejavu-core \
+	&& apt-get autoremove -y \
+	&& rm -rf /var/lib/{apt,dpkg,cache,log}/ \
+	&& rm -rf /var/{cache,log}
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 CMD ["R"]


### PR DESCRIPTION
Hello. I was able to reduce the image size down to about 180MB [as it says in docker hub](https://hub.docker.com/r/iron/r-base/tags/) from the 409MB for the current image just by moving some stuff around. there may be more build dependencies that we can clean but I just did a few obvious ones and left it for now. as it shows after the full pull this image takes up about 1GB on my machine, where the version using this updated Dockerfile now takes up 385MB so this is a big saving when building on top of this image and pulling it. I hope these changes are useful for you, too. Thanks for the base image 