### PR TITLE
Included libssl1.0.0 as a dependency

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -19,6 +19,7 @@ RUN rm -rf /var/lib/apt/lists/ \
     libapparmor1 \
     libedit2 \
     libcurl4-openssl-dev \
+    libssl1.0.0 \
     libssl-dev \
     psmisc \
     supervisor \


### PR DESCRIPTION
RStudio server needs libssl1.0.0 or else it gives an error.