### PR TITLE
Do not daemonize rstudio on init (closes #178)

### DIFF
--- a/rstudio/run.sh
+++ b/rstudio/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-exec /usr/lib/rstudio-server/bin/rserver
+exec /usr/lib/rstudio-server/bin/rserver --server-daemonize 0
 


### PR DESCRIPTION
The rstudio container init script starts the RStudio server using the default startup options, which includes daemonize. This confuses the init system to repeatedly try to start the server even though it's already started.

This changes the start up script to not start the server daemonized, and let the init system take care of it.

Fixes https://github.com/rocker-org/rocker/issues/178