### PR TITLE
User creation fix

### DIFF
--- a/rstudio/userconf.sh
+++ b/rstudio/userconf.sh
@@ -5,6 +5,7 @@ USER=${USER:=rstudio}
 PASSWORD=${PASSWORD:=rstudio}
 USERID=${USERID:=1000}
 ROOT=${ROOT:=FALSE}
+DEL_DEFAULT_USER=${DEL_DEFAULT_USER:=FALSE}
 
 if [ "$USERID" -ne 1000 ]
 ## Configure user with a different USERID if requested.
@@ -35,6 +36,13 @@ if [ "$ROOT" == "TRUE" ]
 	then
 		adduser $USER sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 		echo "$USER added to sudoers"
+fi
+
+# Delete default user (rstudio)
+if [ "$DEL_DEFAULT_USER" == "TRUE" ]
+	then
+		userdel -rf rstudio
+		echo "User rstudio deleted"
 fi
 
 ## add these to the global environment so they are avialable to the RStudio user 

--- a/rstudio/userconf.sh
+++ b/rstudio/userconf.sh
@@ -6,7 +6,7 @@ PASSWORD=${PASSWORD:=rstudio}
 USERID=${USERID:=1000}
 ROOT=${ROOT:=FALSE}
 
-if [ $USERID -ne 1000 ]
+if [ "$USERID" -ne 1000 ]
 ## Configure user with a different USERID if requested.
 	then
 		echo "deleting user rstudio"


### PR DESCRIPTION
Now rstudio/rstudio credentials work if custom username and uid are set. This gives an option to close that hole, especially for servers accessible from the Internet