### PR TITLE
Add tex gyre fonts to Ubuntu Dockerfiles

### DIFF
--- a/r-apt/precise/Dockerfile
+++ b/r-apt/precise/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
 		vim-tiny \
 		wget \
 		ca-certificates \
+        tex-gyre \
         && add-apt-repository -y "ppa:marutter/rrutter" \
 	&& add-apt-repository -y "ppa:marutter/c2d4u" \
         && apt-get update 

--- a/r-apt/trusty/Dockerfile
+++ b/r-apt/trusty/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
 		vim-tiny \
 		wget \
 		ca-certificates \
+        fonts-texgyre \
         && add-apt-repository -y "ppa:marutter/rrutter" \
 	&& add-apt-repository -y "ppa:marutter/c2d4u" \
         && apt-get update 

--- a/r-apt/wily/Dockerfile
+++ b/r-apt/wily/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
 		vim-tiny \
 		wget \
 		ca-certificates \
+        fonts-texgyre \
         && add-apt-repository --enable-source --yes "ppa:marutter/rrutter" \
 	&& add-apt-repository --enable-source --yes "ppa:marutter/c2d4u" 
 

--- a/r-apt/xenial/Dockerfile
+++ b/r-apt/xenial/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
 		vim-tiny \
 		wget \
 		ca-certificates \
+        fonts-texgyre \
         && add-apt-repository --enable-source --yes "ppa:marutter/rrutter" \
 	&& add-apt-repository --enable-source --yes "ppa:marutter/c2d4u" 
 


### PR DESCRIPTION
This is a followup to #190. For trusty, wily, and xenial, the package is fonts-texgyre. For precise, the package is tex-gyre.