### PR TITLE
Added pandoc and qpdf to r-base

### DIFF
--- a/r-base/Dockerfile
+++ b/r-base/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update \
 		ed \
 		less \
 		locales \
+		pandoc \
+		qpdf \
 		vim-tiny \
 		wget \
 		ca-certificates \


### PR DESCRIPTION
I'm pretty new to Docker and rocker, but thought I'd try a suggestion. `pandoc` appears to be used to compile markdown during `R CMD build`. And `qpdf` appears to be used to check pdf files during building. Should this be added to the images at rocker?

Thank you for providing this resource (and all the other wonderful resources)!
Brian