### PR TITLE
Use debian:testing-slim image to save 94MB

### DIFF
--- a/r-base/Dockerfile
+++ b/r-base/Dockerfile
@@ -1,6 +1,6 @@
 ## Emacs, make this -*- mode: sh; -*-
  
-FROM debian:testing
+FROM debian:testing-slim
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/r-base" \


### PR DESCRIPTION
Using the official Debian `-slim` images saves 94MB (594MB vs 688MB) in the built image.