### PR TITLE
Fixes to non-root user (docker) creation commands and non-root user's permissions

### DIFF
--- a/r-base/latest/Dockerfile
+++ b/r-base/latest/Dockerfile
@@ -10,10 +10,8 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ## Set a default user. Available via runtime flag `--user docker`
 ## Add user to 'staff' group, granting them write privileges to /usr/local/lib/R/site.library
 ## User should also have & own a home directory (for rstudio or linked volumes to work properly).
-RUN useradd docker \
-	&& mkdir /home/docker \
-	&& chown docker:docker /home/docker \
-	&& adduser docker staff
+RUN useradd -s /bin/bash -m docker \
+	&& usermod -a -G staff docker
 
 ## NB: No 'apt-get upgrade -y' in official images, see eg
 ## https://github.com/docker-library/official-images/pull/13443#issuecomment-1297829291

--- a/r-base/latest/Dockerfile
+++ b/r-base/latest/Dockerfile
@@ -56,6 +56,8 @@ RUN apt-get update \
 		r-base-dev=${R_BASE_VERSION}-* \
                 r-base-core=${R_BASE_VERSION}-* \
 		r-recommended=${R_BASE_VERSION}-* \
+	&& chown root:staff "/usr/local/lib/R/site-library" \
+	&& chmod g+ws "/usr/local/lib/R/site-library" \
 	&& ln -s /usr/lib/R/site-library/littler/examples/install.r /usr/local/bin/install.r \
 	&& ln -s /usr/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
 	&& ln -s /usr/lib/R/site-library/littler/examples/installBioc.r /usr/local/bin/installBioc.r \


### PR DESCRIPTION
Fix #513, Addresses #517

The user creation command has been replaced with the `rocker/r-ver` one (set default shell, create home dir at once).
https://github.com/rocker-org/rocker-versioned2/blob/74e609121d784d54841ec27594e3c3a7f2dc3e1c/scripts/default_user.sh#L10-L12

Also, the site-library permissions have been changed so that the `staff` group can update as like `rocker/r-ver`.
https://github.com/rocker-org/rocker-versioned2/blob/74e609121d784d54841ec27594e3c3a7f2dc3e1c/scripts/install_R_source.sh#L143-L144

I tried to build and test locally, but got the following error...
Perhaps because it is just before the R 4.2.3 release?

```log
#9 10.55 Package r-base-core is not available, but is referred to by another package.
#9 10.55 This may mean that the package is missing, has been obsoleted, or
#9 10.55 is only available from another source
#9 10.55 
#9 10.55 Package r-base is not available, but is referred to by another package.
#9 10.55 This may mean that the package is missing, has been obsoleted, or
#9 10.55 is only available from another source
#9 10.55 However the following packages replace it:
#9 10.55   r-base-core r-doc-info r-doc-html r-base-html
#9 10.55 
#9 10.55 Package r-recommended is not available, but is referred to by another package.
#9 10.55 This may mean that the package is missing, has been obsoleted, or
#9 10.55 is only available from another source
#9 10.55 However the following packages replace it:
#9 10.55   r-cran-mgcv r-cran-survival r-cran-rpart r-base-html r-base-core r-cran-boot
#9 10.55   r-cran-nlme r-cran-lattice r-cran-kernsmooth r-cran-foreign r-cran-cluster
#9 10.55 
#9 10.55 Package r-base-dev is not available, but is referred to by another package.
#9 10.55 This may mean that the package is missing, has been obsoleted, or
#9 10.55 is only available from another source
#9 10.55 
#9 10.56 E: Version '4.2.2-*' for 'r-base' was not found
#9 10.56 E: Version '4.2.2-*' for 'r-base-dev' was not found
#9 10.56 E: Version '4.2.2-*' for 'r-base-core' was not found
#9 10.56 E: Version '4.2.2-*' for 'r-recommended' was not found
------
executor failed running [/bin/sh -c apt-get update         && apt-get install -y --no-install-recommends                 libopenblas0-pthread             littler                 r-cran-docopt                 r-cran-littler     r-base=${R_BASE_VERSION}-*               r-base-dev=${R_BASE_VERSION}-*                 r-base-core=${R_BASE_VERSION}-*            r-recommended=${R_BASE_VERSION}-*       && chown root:staff "/usr/local/lib/R/site-library"     && chmod g+ws "/usr/local/lib/R/site-library"     && ln -s /usr/lib/R/site-library/littler/examples/install.r /usr/local/bin/install.r      && ln -s /usr/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r  && ln -s /usr/lib/R/site-library/littler/examples/installBioc.r /usr/local/bin/installBioc.r      && ln -s /usr/lib/R/site-library/littler/examples/installDeps.r /usr/local/bin/installDeps.r      && ln -s /usr/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r  && ln -s /usr/lib/R/site-library/littler/examples/testInstalled.r /usr/local/bin/testInstalled.r  && rm -rf /tmp/downloaded_packages/ /tmp/*.rds  && rm -rf /var/lib/apt/lists/*]: exit code: 100
```